### PR TITLE
Add assignment screenshots table and regenerate Supabase types

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -14,6 +14,54 @@ export type Database = {
   }
   public: {
     Tables: {
+      assignment_screenshots: {
+        Row: {
+          assignment_id: string
+          drive_file_id: string | null
+          drive_view_url: string | null
+          file_name: string
+          id: string
+          notes: string | null
+          product_id: string | null
+          uploaded_at: string
+        }
+        Insert: {
+          assignment_id: string
+          drive_file_id?: string | null
+          drive_view_url?: string | null
+          file_name: string
+          id?: string
+          notes?: string | null
+          product_id?: string | null
+          uploaded_at?: string
+        }
+        Update: {
+          assignment_id?: string
+          drive_file_id?: string | null
+          drive_view_url?: string | null
+          file_name?: string
+          id?: string
+          notes?: string | null
+          product_id?: string | null
+          uploaded_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "assignment_screenshots_assignment_id_fkey"
+            columns: ["assignment_id"]
+            isOneToOne: false
+            referencedRelation: "user_assignments"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "assignment_screenshots_product_id_fkey"
+            columns: ["product_id"]
+            isOneToOne: false
+            referencedRelation: "products"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       assignment_texts: {
         Row: {
           assignment_id: string

--- a/supabase/migrations/20251001090000_add_assignment_screenshots.sql
+++ b/supabase/migrations/20251001090000_add_assignment_screenshots.sql
@@ -1,0 +1,17 @@
+-- Create assignment_screenshots table
+CREATE TABLE public.assignment_screenshots (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  assignment_id UUID NOT NULL REFERENCES public.user_assignments(id) ON DELETE CASCADE,
+  product_id UUID REFERENCES public.products(id) ON DELETE SET NULL,
+  drive_file_id TEXT,
+  drive_view_url TEXT,
+  file_name TEXT NOT NULL,
+  uploaded_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  notes TEXT
+);
+
+-- Enable RLS on assignment_screenshots
+ALTER TABLE public.assignment_screenshots ENABLE ROW LEVEL SECURITY;
+
+-- Allow anonymous access consistent with existing strategy
+CREATE POLICY "Public manage assignment screenshots" ON public.assignment_screenshots FOR ALL USING (true);


### PR DESCRIPTION
## Summary
- add a migration to create the assignment_screenshots table with anonymous access policy
- regenerate the Supabase typed client so assignment_screenshots is available in the app

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dbbcab02488328a63d5bae480ee8b7