### PR TITLE
Implement Resend email sending for notifications

### DIFF
--- a/supabase/functions/send-notification/index.test.ts
+++ b/supabase/functions/send-notification/index.test.ts
@@ -1,0 +1,74 @@
+import { assertEquals } from "https://deno.land/std@0.190.0/testing/asserts.ts";
+import { RESEND_API_URL, sendNotificationEmail } from "./index.ts";
+
+const originalFetch = globalThis.fetch;
+
+Deno.test("sendNotificationEmail returns success when provider responds with ok", async () => {
+  globalThis.fetch = async (input, init) => {
+    assertEquals(input, RESEND_API_URL);
+    assertEquals(init?.method, "POST");
+    const body = typeof init?.body === "string" ? JSON.parse(init.body) : {};
+    assertEquals(body.to, ["user@example.com"]);
+    return new Response("{\"id\":\"email_1\"}", { status: 200 });
+  };
+
+  try {
+    const result = await sendNotificationEmail({
+      apiKey: "test_key",
+      from: "sender@example.com",
+      to: "user@example.com",
+      subject: "Test",
+      html: "<p>Hello</p>",
+    });
+
+    assertEquals(result.success, true);
+    assertEquals(result.status, 200);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("sendNotificationEmail surfaces provider error responses", async () => {
+  globalThis.fetch = async () => {
+    return new Response("{\"error\":\"invalid\"}", { status: 422 });
+  };
+
+  try {
+    const result = await sendNotificationEmail({
+      apiKey: "test_key",
+      from: "sender@example.com",
+      to: "user@example.com",
+      subject: "Test",
+      html: "<p>Hello</p>",
+    });
+
+    assertEquals(result.success, false);
+    assertEquals(result.status, 422);
+    assertEquals(result.message, "Failed to send email via Resend");
+    assertEquals(result.body, '{"error":"invalid"}');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("sendNotificationEmail returns 500 when fetch throws", async () => {
+  globalThis.fetch = async () => {
+    throw new Error("network down");
+  };
+
+  try {
+    const result = await sendNotificationEmail({
+      apiKey: "test_key",
+      from: "sender@example.com",
+      to: "user@example.com",
+      subject: "Test",
+      html: "<p>Hello</p>",
+    });
+
+    assertEquals(result.success, false);
+    assertEquals(result.status, 500);
+    assertEquals(result.message, "network down");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary
- integrate the Resend email API into the send-notification function and require a configured API key
- only mark notifications as sent after the external provider succeeds and return errors for failures
- add unit tests for the email sending helper to cover success, provider errors, and thrown exceptions

## Testing
- deno test supabase/functions/send-notification/index.test.ts *(fails: deno not installed in container)*

------
https://chatgpt.com/codex/tasks/task_b_68dbbbd088f483289f2ec7b9f9e2e475