### PR TITLE
Add Supabase policies for managing campaigns

### DIFF
--- a/supabase/migrations/20251002100000_campaign_policies.sql
+++ b/supabase/migrations/20251002100000_campaign_policies.sql
@@ -1,0 +1,13 @@
+-- Grant anonymous insert/update/delete access to campaigns
+CREATE POLICY "Public insert campaigns" ON public.campaigns
+  FOR INSERT
+  WITH CHECK (true);
+
+CREATE POLICY "Public update campaigns" ON public.campaigns
+  FOR UPDATE
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY "Public delete campaigns" ON public.campaigns
+  FOR DELETE
+  USING (true);


### PR DESCRIPTION
## Summary
- add row-level security policies to allow anonymous inserts, updates, and deletes on public.campaigns

## Testing
- supabase migration up *(fails: supabase CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dbce08c3e0832897bc87490020bd23