### PR TITLE
Add Supabase policies for products and texts

### DIFF
--- a/supabase/migrations/20251002103000_product_text_policies.sql
+++ b/supabase/migrations/20251002103000_product_text_policies.sql
@@ -1,0 +1,26 @@
+-- Grant anonymous insert/update/delete access to products and texts
+CREATE POLICY "Public insert products" ON public.products
+  FOR INSERT
+  WITH CHECK (true);
+
+CREATE POLICY "Public update products" ON public.products
+  FOR UPDATE
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY "Public delete products" ON public.products
+  FOR DELETE
+  USING (true);
+
+CREATE POLICY "Public insert texts" ON public.texts
+  FOR INSERT
+  WITH CHECK (true);
+
+CREATE POLICY "Public update texts" ON public.texts
+  FOR UPDATE
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY "Public delete texts" ON public.texts
+  FOR DELETE
+  USING (true);


### PR DESCRIPTION
## Summary
- add RLS policies for products and texts matching the campaign policies so admins can manage related data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dbd50390bc8328aa47e65471f7cd7c